### PR TITLE
Prevent division by 0 and crash of service on too early or bad sensor…

### DIFF
--- a/roles/power/files/gpdfand.py
+++ b/roles/power/files/gpdfand.py
@@ -35,7 +35,10 @@ def get_temp():
             with io.open(temp_input_dev, 'r') as core_temp:
                 temp = int(core_temp.read()) / 1000
                 temps.append(temp)
-    return sum(temps) / float(len(temps))
+    if(len(temps) > 0): 	
+        return sum(temps) / float(len(temps))
+    else:
+        return 0
 
 # Set fans function
 def set_fans(a,b):
@@ -67,7 +70,7 @@ while True:
     temp = get_temp()
 
     # Set fan speed
-    if temp >= args.max:
+    if temp >= args.max or temp == 0:
         set_fans(1,1)
     elif temp >= args.med:
         set_fans(0,1)


### PR DESCRIPTION
… read

On a live environment may happen that the method "get_temp" fail with a division per zero error on boot, this causes the service to stop.
This could be related to a too early try to read the sensor or something related to loading of services and sensors.
This always happen on a live environment ISO.
This could happen also if sensor is broken or defective. On a zero read the script should put fan on max just to be sure that it keeps everything cool as ErikaFluff perl script do.