### PR TITLE
Touchscreen ID may be different from '11' on boot or Wayland

### DIFF
--- a/roles/xorg/files/gpdrotate.sh
+++ b/roles/xorg/files/gpdrotate.sh
@@ -15,4 +15,18 @@ xrandr --output DSI1 --rotate right
 sleep 5
 
 # rotate touchscreen
-xinput set-prop 11 "Coordinate Transformation Matrix" 0 1 0 -1 0 1 0 0 1
+SEARCH="Goodix Capacitive TouchScreen"
+
+ids=$(xinput --list | awk -v search="$SEARCH" \
+    '$0 ~ search {match($0, /id=[0-9]+/);\
+            if (RSTART) \
+              print substr($0, RSTART+3, RLENGTH-3)\
+           }'\
+     )
+
+# Rotate every instance of Touchscreen, this will workaround the ambiguity warning problem
+# that arise when calling xinput on "Goodix Capacitive Touchscreen"
+for i in $ids
+do
+    xinput set-prop $i "Coordinate Transformation Matrix" 0 1 0 -1 0 1 0 0 1
+done


### PR DESCRIPTION
Sometimes, rare occasion, touchscreen gets addressed with id different from 11 on boot.
Script should be smart enough to read correct id and act as needed to correctly patch transformation matrix.
Using "Goodix Capacitive Touchscreen" is not enough as xinput will crash blaming for ambiguity. (Two devices with same name)