### PR TITLE
fixed an issue where the ubuntu installer would crash while installin…

### DIFF
--- a/roles/packages/tasks/debian.yml
+++ b/roles/packages/tasks/debian.yml
@@ -5,7 +5,6 @@
   - build-essential
   - debian-installer-launcher
   - git
-  - grub2
   - gstreamer1.0-vaapi
   - i965-va-driver
   - libelf-dev


### PR DESCRIPTION
…g grub package

Due to some issues with the grub2 package, the installer of Ubuntu crashed, excluding grub worked, be aware that this could break other Debian based distros, i could not check them yet.