### PR TITLE
[Re-created] split install btrfs package function

### DIFF
--- a/roles/boot/tasks/debian.yml
+++ b/roles/boot/tasks/debian.yml
@@ -1,8 +1,24 @@
 ---
-- name: install essential packages (this may take a while)
+- name: install btrfs package (Ubuntu 16.04 or less)
+  apt: name="{{ item }}"
+  with_items:
+  - btrfs-tools
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version|float <= 16.04
+  tags:
+  - boot
+
+- name: install btrfs package (Ubuntu 16.10 or above || Other Distribution)
   apt: name="{{ item }}"
   with_items:
   - btrfs-progs
+  when: ansible_distribution != 'Ubuntu' or
+        (ansible_distribution == 'Ubuntu' and ansible_distribution_version|float >= 16.10)
+  tags:
+  - boot
+
+- name: install essential packages (this may take a while)
+  apt: name="{{ item }}"
+  with_items:
   - build-essential
   - debian-installer-launcher
   - libelf-dev


### PR DESCRIPTION
split install btrfs package function
  - Ubuntu 16.04 or less
  - Ubuntu 16.04 or above OR other distribution