### PR TITLE
Fix: "Unable to find a medium containing a live file system #68"

### DIFF
--- a/roles/iso/tasks/debian/install-initrd.yml
+++ b/roles/iso/tasks/debian/install-initrd.yml
@@ -11,6 +11,8 @@
       cd -
       echo "changed"
     fi
+  args:
+    executable: /bin/bash
   register: install_initrd
   changed_when: install_initrd.stdout | search('changed')
   with_items: "{{ iso_initrds.results | map(attribute='files') | list }}"

--- a/roles/iso/tasks/main.yml
+++ b/roles/iso/tasks/main.yml
@@ -203,6 +203,8 @@
     if [[ "{{ item.path }}" != *'/install/'* ]] && [[ "{{ item.path }}" != *'/d-i/'* ]]; then
       cp -fv "{{ system_initrd.files.0.path }}" "{{ item.path }}"
     fi
+  args:
+    executable: /bin/bash
   with_items: "{{ iso_initrds.results | map(attribute='files') | list }}"
   tags:
   - iso


### PR DESCRIPTION
On Ubuntu dash is the default shell linked onto /bin/sh. The dash shell
provides a quite different command syntax that does not support some of
the features that are required during the installation of the initrd.

As Ansible is always using the default shell for "shell" commands, if
not explicitely defined, it should be set on all commands that need
bash-specific syntax.