### PR TITLE
introduce GPD_BOOTSTRAP_NO_GIT_PULL for easier development

### DIFF
--- a/bootstrap-iso.sh
+++ b/bootstrap-iso.sh
@@ -21,7 +21,7 @@ elif [ -f /usr/sbin/emerge ]; then
 fi
 
 # update ansible code
-if [ -d .git ]; then
+if [ -d .git -a "x" == "x$GPD_BOOTSTRAP_NO_GIT_PULL" ]; then
   git reset --hard
   git pull
 fi


### PR DESCRIPTION
I have an environment variable that should allow to disable automatic pull requests within the build script. That should allow testing new stuff without having to push all the time.
