### PR TITLE
Remove explicit cloning from external repository when we can avoid that.

### DIFF
--- a/bootstrap-system.sh
+++ b/bootstrap-system.sh
@@ -56,8 +56,12 @@ elif [ -f /usr/sbin/emerge ]; then
 fi
 
 # update ansible code
-rm -rf /usr/src/ansible-gpdpocket
-git clone --depth 1 https://github.com/cawilliamson/ansible-gpdpocket.git /usr/src/ansible-gpdpocket
+if $(echo $@ | grep -q "\--nogit"); then
+  echo "skip pulling source from git"
+else
+  rm -rf /usr/src/ansible-gpdpocket
+  git clone --depth 1 https://github.com/cawilliamson/ansible-gpdpocket.git /usr/src/ansible-gpdpocket
+fi
 cd /usr/src/ansible-gpdpocket
 
 # run ansible scripts

--- a/roles/iso/tasks/main.yml
+++ b/roles/iso/tasks/main.yml
@@ -136,7 +136,7 @@
 
 - include: fedora/mount-rootfs.yml
   when: iso | lower | search('centos') or iso | lower | search('fedora') or iso | lower | search('redhat')
-  
+
 - include: gentoo/mount-bind.yml
   when: iso | lower | search('gentoo')
 
@@ -168,15 +168,23 @@
   tags:
   - iso
 
-- name: copy bootstrap-system script to guest
-  copy:
-    src: ../../bootstrap-system.sh
-    dest: /var/tmp/bootstrap-iso/squashfs/tmp/bootstrap-system.sh
+- name: create playbook directory on guest
+  file:
+    path: /var/tmp/bootstrap-iso/squashfs/usr/src/ansible-gpdpocket
+    state: directory
+    recurse: yes
+
+- name: sync playbook directory to guest
+  synchronize:
+    src: ../../../
+    dest: /var/tmp/bootstrap-iso/squashfs/usr/src/ansible-gpdpocket
+    recursive: yes
+  delegate_to: localhost
   tags:
   - iso
 
 - name: bootstrap guest (this may take a while)
-  shell: chroot /var/tmp/bootstrap-iso/squashfs /bin/bash -c "/bin/bash /tmp/bootstrap-system.sh"
+  shell: chroot /var/tmp/bootstrap-iso/squashfs /bin/bash -c "/bin/bash /usr/src/ansible-gpdpocket/bootstrap-system.sh --nogit"
   args:
     executable: /bin/bash
   tags:


### PR DESCRIPTION
Cloning here might trigger unexpected behavior whenever the remote repository
changes between starting the iso playbook and cloning the system playbook.

It also makes forking and patching unnecessary complicated.

As I do not know each possible workflow involving the system playbook, please review carefully.
