### PR TITLE
readd initramfs-tools as removing them breaks things (fix: #82)

### DIFF
--- a/roles/boot/tasks/debian.yml
+++ b/roles/boot/tasks/debian.yml
@@ -5,7 +5,7 @@
     state: "{{ item.state }}"
   with_items:
   - { name: 'debian-installer-launcher', state: 'present' }
-  - { name: 'initramfs-tools', state: 'absent' }
+  - { name: 'initramfs-tools', state: 'present' }
   - { name: 'live-boot', state: 'present' }
   - { name: 'live-tools', state: 'present' }
   - { name: 'intel-microcode', state: 'absent' }


### PR DESCRIPTION
I do not know the reason, why you actually decided to remove this package but this breaks ubuntu and xubuntu live-cds.

If we need an exception here to be properly able to build debian images, please feel free to reject. I could also implement an exception regarding ubuntu here instead.