### PR TITLE
fix: scripts are world writable and are executed as root.

### DIFF
--- a/roles/common/tasks/update.yml
+++ b/roles/common/tasks/update.yml
@@ -5,7 +5,7 @@
     dest: /usr/local/bin/gpd-update
     owner: root
     group: root
-    mode: 0777
+    mode: 0755
   tags:
   - common
   - update

--- a/roles/xorg/tasks/main.yml
+++ b/roles/xorg/tasks/main.yml
@@ -153,9 +153,9 @@
     mode: "{{ item.mode }}"
   with_items:
   - { src: 'files/rotate/01gpd-rotate', dest: '/etc/X11/Xsession.d/01gpd-rotate', mode: '0644' }
-  - { src: 'files/rotate/01gpd-rotate', dest: '/etc/X11/xinit/xinitrc.d/01gpd-rotate', mode: '0777' }
+  - { src: 'files/rotate/01gpd-rotate', dest: '/etc/X11/xinit/xinitrc.d/01gpd-rotate', mode: '0755' }
   - { src: 'files/rotate/gpd-rotate.conf', dest: '/etc/gpd/rotate.conf', mode: '0644' }
-  - { src: 'files/rotate/gpd-rotate.py', dest: '/usr/local/sbin/gpd-rotate', mode: '0777' }
+  - { src: 'files/rotate/gpd-rotate.py', dest: '/usr/local/sbin/gpd-rotate', mode: '0755' }
   - { src: 'files/rotate/gpd-rotate.service', dest: '/etc/systemd/system/gpd-rotate.service', mode: '0644' }
   notify:
   - enable gpd-rotate


### PR DESCRIPTION
This provides direct vector for privilege escalation and should be changed soon.