### PR TITLE
Use highest temperature core to determine fan speed

### DIFF
--- a/roles/power/files/gpd-fan.py
+++ b/roles/power/files/gpd-fan.py
@@ -36,7 +36,7 @@ def get_temp():
                 temp = int(core_temp.read()) / 1000
                 temps.append(temp)
     if(len(temps) > 0): 	
-        return sum(temps) / float(len(temps))
+        return max(temps)
     else:
         return 0
 


### PR DESCRIPTION
Since single core running tasks can take one core up in temperature considerably compared to the rest, and since Atom Z8750 has a single core burst mode of 2.5 GHz, it's better to use the core with the highest temperature rather than the average.

Upstream PR: https://github.com/efluffy/gpdfand/pull/6
Upstream issue: https://github.com/efluffy/gpdfand/issues/5